### PR TITLE
Fix ServerURL extract when checking out the GitLab source repository

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2856,7 +2856,7 @@ try  {
     const commitEmail = core.getInput('commitEmail');
     const configRepoName = core.getInput('configRepoName');
     const serverUrl = core.getInput('serverUrl');
-    const urlWithoutProtocol = serverUrl.replace(/^https:\/\//, '');
+    const urlWithoutProtocol = serverUrl.replace(/^https?:\/\//, '');
     const ref = core.getInput('ref');
 
     console.log("Started removing files in current directory");

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ try  {
     const commitEmail = core.getInput('commitEmail');
     const configRepoName = core.getInput('configRepoName');
     const serverUrl = core.getInput('serverUrl');
-    const urlWithoutProtocol = serverUrl.replace(/^https:\/\//, '');
+    const urlWithoutProtocol = serverUrl.replace(/^https?:\/\//, '');
     const ref = core.getInput('ref');
 
     console.log("Started removing files in current directory");


### PR DESCRIPTION
This is to update the logic to extract the Server URL when checking out to the source repository. This fix will update the existing logic to support both HTTPS and HTTP URLs. 
Related issue - https://github.com/wso2-enterprise/choreo/issues/32989